### PR TITLE
Handle&retry http error 524 timeout

### DIFF
--- a/src/APIClient.ts
+++ b/src/APIClient.ts
@@ -67,7 +67,8 @@ export class APIClient {
         this.socket.close();
         const RequestTimeout = 408;
         const ServiceUnavailable = 503;
-        if (res.statusCode === ServiceUnavailable || res.statusCode === RequestTimeout) {
+        const CfRequestTimeout = 524;
+        if (res.statusCode === ServiceUnavailable || res.statusCode === RequestTimeout || res.statusCode === CfRequestTimeout) {
           console.warn(
             `Connection to ${this.server} failed: ${res.statusMessage ?? ''} (${res.statusCode}).`,
           );


### PR DESCRIPTION
10% of runs was getting 524 cloudflare timeout error, this handles the error gracefully and continues in the retry path.

```
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-8.2.2, pluggy-1.5.0
rootdir: /__w/AtomVM/AtomVM/src/platforms/esp32/test
plugins: embedded-1.10.3
collected 2 items / 1 deselected / 1 selected
test_atomvm.py 2024-06-14 08:48:34 Wokwi CLI v0.11.1 (6bd2f7b31a55)
2024-06-14 08:50:14 Error: Error connecting to wss://wokwi.com/api/ws/beta: 524 
2024-06-14 08:50:14     at _WebSocket.<anonymous> (/snapshot/dist/cli.cjs:13525:13)
2024-06-14 08:50:14     at _WebSocket.emit (node:events:518:28)
2024-06-14 08:50:14     at ClientRequest.<anonymous> (/snapshot/dist/cli.cjs:10111:31)
2024-06-14 08:50:14     at ClientRequest.emit (node:events:518:28)
2024-06-14 08:50:14     at HTTPParser.parserOnIncomingClient (node:_http_client:693:27)
2024-06-14 08:50:14     at HTTPParser.parserOnHeadersComplete (node:_http_common:119:17)
2024-06-14 08:50:14     at TLSSocket.socketOnData (node:_http_client:535:22)
2024-06-14 08:50:14     at TLSSocket.emit (node:events:518:28)
2024-06-14 08:50:14     at addChunk (node:internal/streams/readable:559:12)
2024-06-14 08:50:14     at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
```