### PR TITLE
Handle aarch64 -> arm64

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,6 +19,7 @@ main() {
 
   case "$arch" in
   x86_64) arch="x64" ;;
+  aarch64) arch="arm64" ;;
   arm64) ;;
   *) echo "Unsupported architecture: $arch"; exit 1 ;;
   esac


### PR DESCRIPTION
when using **act** (local github actions: https://github.com/nektos/act) on m1 macs the container arch for arm64 is reported as _aarch64_, and thus results in this error when running the install.sh script:

```
[ESP32 Sim test/esp-sim-test            ]   🐳  docker exec cmd=[sh -e /var/run/act/workflow/2.sh] user= workdir=
|   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
|                                  Dload  Upload   Total   Spent    Left  Speed
100    15    0    15    0     0    128      0 --:--:-- --:--:-- --:--:--   128
100  2102  100  2102    0     0  13828      0 --:--:-- --:--:-- --:--:-- 13828
| Unsupported architecture: aarch64
```

PR fixes this - tested and verified.

