### PR TITLE
Parse firmware size from flasher_args.json

### DIFF
--- a/packages/cli/src/uploadFirmware.ts
+++ b/packages/cli/src/uploadFirmware.ts
@@ -8,10 +8,40 @@ interface IFirmwarePiece {
   data: Uint8Array;
 }
 
-const MAX_FIRMWARE_SIZE = 4 * 1024 * 1024;
+function parseBinarySize(input: string): number {
+  const match = input.trim().match(/^(\d+)\s*(KB|MB|GB|TB)?$/i);
+
+  if (!match) {
+    throw new Error(`Invalid size format: "${input}"`);
+  }
+
+  const value = Number(match[1]);
+  const unit = match[2]?.toUpperCase();
+
+  switch (unit) {
+    case undefined:
+      return value; // bytes
+    case 'KB':
+      return value * 1024;
+    case 'MB':
+      return value * 1024 ** 2;
+    case 'GB':
+      return value * 1024 ** 3;
+    case 'TB':
+      return value * 1024 ** 4;
+    default:
+      // unreachable due to regex, but keeps TS happy
+      throw new Error(`Unsupported unit: ${unit}`);
+  }
+}
 
 export async function uploadESP32Firmware(client: APIClient, firmwarePath: string) {
   const flasherArgs = JSON.parse(readFileSync(firmwarePath, 'utf-8')) as IESP32FlasherJSON;
+  if (!('flash_settings' in flasherArgs) || !('flash_size' in flasherArgs.flash_settings)) {
+    throw new Error('flash_settings or flash_size is not defined in flasher_args.json');
+  }
+  const maxFirmwareSize = parseBinarySize(flasherArgs.flash_settings.flash_size);
+
   if (!('flash_files' in flasherArgs)) {
     throw new Error('flash_files is not defined in flasher_args.json');
   }
@@ -29,9 +59,9 @@ export async function uploadESP32Firmware(client: APIClient, firmwarePath: strin
     firmwareSize = Math.max(firmwareSize, offsetNum + data.byteLength);
   }
 
-  if (firmwareSize > MAX_FIRMWARE_SIZE) {
+  if (firmwareSize > maxFirmwareSize) {
     throw new Error(
-      `Firmware size (${firmwareSize} bytes) exceeds the maximum supported size (${MAX_FIRMWARE_SIZE} bytes)`,
+      `Firmware size (${firmwareSize} bytes) exceeds the flash capacity (${maxFirmwareSize} bytes)`,
     );
   }
 


### PR DESCRIPTION
Instead of assuming a maximum of 4MB flash size check from the configuration.

Fixes #41.